### PR TITLE
Fix menu toggle null reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -545,10 +545,13 @@
         }
     });
 
-    // Hamburger Menu Toggle
-    document.getElementById('menuToggle').addEventListener('click', function() {
-        document.querySelector('.nav-tabs').classList.toggle('open');
-    });
+    // Hamburger Menu Toggle (nur wenn Element existiert)
+    const menuToggle = document.getElementById('menuToggle');
+    if (menuToggle) {
+        menuToggle.addEventListener('click', function() {
+            document.querySelector('.nav-tabs').classList.toggle('open');
+        });
+    }
         });
         
         // Standard-Produkte hinzufügen


### PR DESCRIPTION
## Summary
- prevent JS error when `menuToggle` element is missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843fd6a229c8320941577520f6cd13e