### PR TITLE
Implement CSV export

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,6 +317,7 @@
         <p>Zentrale Eingabemaske mit automatischer Berechnung</p>
         <button id="darkModeToggle" class="btn">🌙 Dark Mode</button>
         <button id="backupBtn" class="btn">💾 Backup</button>
+        <button id="csvExportBtn" class="btn">📄 CSV Export</button>
         <button id="importBtn" class="btn">📂 Import</button>
         <input type="file" id="importFile" accept=".json" style="display:none">
         <button id="resetBtn" class="btn btn-danger">↻ Reset</button>
@@ -1004,6 +1005,35 @@
             const a = document.createElement('a');
             a.href = url;
             a.download = 'getraenke_backup.json';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        });
+
+        // CSV-Export der Eingaben
+        document.getElementById('csvExportBtn').addEventListener('click', function() {
+            if (eingaben.length === 0) {
+                alert('Keine Eingaben zum Exportieren!');
+                return;
+            }
+
+            // Spalten ermitteln
+            const headers = [];
+            eingaben.forEach(e => {
+                Object.keys(e).forEach(k => {
+                    if (!headers.includes(k)) headers.push(k);
+                });
+            });
+
+            const rows = eingaben.map(e => headers.map(h => e[h] !== undefined ? e[h] : '').join(';'));
+            const csvStr = [headers.join(';'), ...rows].join('\n');
+
+            const blob = new Blob([csvStr], { type: 'text/csv;charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'eingaben.csv';
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);


### PR DESCRIPTION
## Summary
- add button for CSV export in header
- implement CSV export for entry data

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843ffb24d6c8320856e07436920ff3c