### PR TITLE
Add inventory and todo features

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,19 @@
             gap: 20px;
             margin-top: 20px;
         }
+
+        .todo-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .todo-list li {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 5px 0;
+            border-bottom: 1px solid #ccc;
+        }
         
         .stat-card {
             background: rgba(255, 255, 255, 0.5);
@@ -378,6 +391,8 @@
             <button class="nav-tab active" onclick="showTab('eingaben')">📋 Eingaben</button>
             <button class="nav-tab" onclick="showTab('produkte')">🥤 Produkte</button>
             <button class="nav-tab" onclick="showTab('auswertung')">📊 Auswertung</button>
+            <button class="nav-tab" onclick="showTab('inventar')">📦 Inventar</button>
+            <button class="nav-tab" onclick="showTab('todo')">✅ To-Dos</button>
             <button class="nav-tab" onclick="showTab('anleitung')">📖 Anleitung</button>
         </div>
         
@@ -485,14 +500,46 @@
         <!-- Auswertung Tab -->
         <div id="auswertung" class="tab-content">
             <h2>Auswertung & Kennzahlen</h2>
-            
+
             <div class="stats-grid" id="statsGrid">
                 <!-- Wird dynamisch gefüllt -->
             </div>
-            
+
             <div id="statusMessage"></div>
         </div>
-        
+
+        <!-- Inventar Tab -->
+        <div id="inventar" class="tab-content">
+            <div style="display:flex; justify-content: space-between; align-items:center; margin-bottom:20px;">
+                <h2>Inventarverwaltung</h2>
+                <div>
+                    <select id="inventarProdukt"></select>
+                    <input type="number" id="inventarMenge" placeholder="Menge" style="width:80px;">
+                    <button class="btn btn-success" onclick="adjustInventarFromForm()">Bestand ändern</button>
+                </div>
+            </div>
+
+            <table class="table" id="inventarTable">
+                <thead>
+                    <tr>
+                        <th>Produkt</th>
+                        <th>Bestand</th>
+                    </tr>
+                </thead>
+                <tbody id="inventarTableBody"></tbody>
+            </table>
+        </div>
+
+        <!-- To-Do Tab -->
+        <div id="todo" class="tab-content">
+            <h2>To-Do Liste</h2>
+            <div style="display:flex; margin-bottom:10px;">
+                <input type="text" id="todoInput" placeholder="Neue Aufgabe" style="flex:1;">
+                <button class="btn btn-success" onclick="addTodo()">Hinzufügen</button>
+            </div>
+            <ul id="todoList" class="todo-list"></ul>
+        </div>
+
         <!-- Anleitung Tab -->
         <div id="anleitung" class="tab-content">
             <h2>📖 Bedienungsanleitung</h2>
@@ -570,6 +617,8 @@
         // Globale Variablen
         let produkte = [];
         let eingaben = [];
+        let inventar = [];
+        let todos = [];
         let users = [];
         let currentUser = null;
         
@@ -597,6 +646,8 @@
             }
             
             updateProduktDropdown();
+            updateInventarDropdown();
+            updateTodoList();
             updateTables();
             updateStats();
     // Dark Mode Toggle
@@ -689,6 +740,7 @@
                 option.textContent = produkt.name;
                 select.appendChild(option);
             });
+            updateInventarDropdown();
         }
         
         // Preise aktualisieren bei Produktauswahl
@@ -843,6 +895,7 @@
             
             saveData();
             updateProduktDropdown();
+            updateInventarDropdown();
             updateTables();
             closeProduktModal();
             
@@ -855,6 +908,7 @@
                 produkte.splice(index, 1);
                 saveData();
                 updateProduktDropdown();
+                updateInventarDropdown();
                 updateTables();
             }
         }
@@ -873,6 +927,8 @@
         function updateTables() {
             updateProdukteTable();
             updateEingabenTable();
+            updateInventarTable();
+            updateTodoList();
         }
         
         // Produkte-Tabelle aktualisieren
@@ -932,6 +988,91 @@
                     </td>
                 `;
             });
+        }
+
+        // Inventar-Dropdown aktualisieren
+        function updateInventarDropdown() {
+            const select = document.getElementById('inventarProdukt');
+            if (!select) return;
+            select.innerHTML = '<option value="">Produkt wählen...</option>';
+            produkte.forEach(p => {
+                const opt = document.createElement('option');
+                opt.value = p.name;
+                opt.textContent = p.name;
+                select.appendChild(opt);
+            });
+        }
+
+        // Inventar-Tabelle aktualisieren
+        function updateInventarTable() {
+            const tbody = document.getElementById('inventarTableBody');
+            if (!tbody) return;
+            tbody.innerHTML = '';
+            inventar.forEach(item => {
+                const row = tbody.insertRow();
+                row.innerHTML = `<td>${item.name}</td><td>${item.quantity}</td>`;
+            });
+        }
+
+        // Bestand aus Formular anpassen
+        function adjustInventarFromForm() {
+            const name = document.getElementById('inventarProdukt').value;
+            const menge = parseInt(document.getElementById('inventarMenge').value);
+            if (!name || isNaN(menge)) {
+                alert('Produkt und Menge angeben!');
+                return;
+            }
+            adjustInventar(name, menge);
+            document.getElementById('inventarMenge').value = '';
+        }
+
+        // Bestand anpassen
+        function adjustInventar(name, diff) {
+            let item = inventar.find(i => i.name === name);
+            if (!item) {
+                item = { name: name, quantity: 0 };
+                inventar.push(item);
+            }
+            item.quantity += diff;
+            if (item.quantity < 0) item.quantity = 0;
+            saveData();
+            updateInventarTable();
+        }
+
+        // To-Do-Liste aktualisieren
+        function updateTodoList() {
+            const list = document.getElementById('todoList');
+            if (!list) return;
+            list.innerHTML = '';
+            todos.forEach((todo, idx) => {
+                const li = document.createElement('li');
+                li.innerHTML = `<span style="text-decoration:${todo.done ? 'line-through' : 'none'}">${todo.text}</span>` +
+                    `<div><button class="btn btn-success" onclick="toggleTodo(${idx})">${todo.done ? '↩️' : '✔️'}</button>` +
+                    `<button class="btn btn-danger" onclick="deleteTodo(${idx})">🗑️</button></div>`;
+                list.appendChild(li);
+            });
+        }
+
+        function addTodo() {
+            const input = document.getElementById('todoInput');
+            const text = input.value.trim();
+            if (!text) return;
+            todos.push({ text: text, done: false });
+            input.value = '';
+            saveData();
+            updateTodoList();
+        }
+
+        function toggleTodo(index) {
+            todos[index].done = !todos[index].done;
+            saveData();
+            updateTodoList();
+        }
+
+        function deleteTodo(index) {
+            todos.splice(index, 1);
+            saveData();
+            updateTodoList();
         }
         
         // Statistiken aktualisieren
@@ -1047,6 +1188,8 @@
             if (currentUser) {
                 localStorage.setItem('getraenke-produkte-' + currentUser.username, JSON.stringify(produkte));
                 localStorage.setItem('getraenke-eingaben-' + currentUser.username, JSON.stringify(eingaben));
+                localStorage.setItem('getraenke-inventar-' + currentUser.username, JSON.stringify(inventar));
+                localStorage.setItem('getraenke-todos-' + currentUser.username, JSON.stringify(todos));
             }
         }
         // Daten laden
@@ -1054,6 +1197,8 @@
             if (!currentUser) return;
             const savedProdukte = localStorage.getItem('getraenke-produkte-' + currentUser.username);
             const savedEingaben = localStorage.getItem('getraenke-eingaben-' + currentUser.username);
+            const savedInventar = localStorage.getItem('getraenke-inventar-' + currentUser.username);
+            const savedTodos = localStorage.getItem('getraenke-todos-' + currentUser.username);
 
             if (savedProdukte) {
                 produkte = JSON.parse(savedProdukte);
@@ -1061,6 +1206,12 @@
 
             if (savedEingaben) {
                 eingaben = JSON.parse(savedEingaben);
+            }
+            if (savedInventar) {
+                inventar = JSON.parse(savedInventar);
+            }
+            if (savedTodos) {
+                todos = JSON.parse(savedTodos);
             }
         }
         
@@ -1075,7 +1226,9 @@
         document.getElementById('backupBtn').addEventListener('click', function() {
             const data = {
                 produkte: produkte,
-                eingaben: eingaben
+                eingaben: eingaben,
+                inventar: inventar,
+                todos: todos
             };
             const jsonStr = JSON.stringify(data, null, 2);
             const blob = new Blob([jsonStr], { type: 'application/json' });
@@ -1132,6 +1285,12 @@
                     if (imported.produkte && imported.eingaben) {
                         localStorage.setItem('getraenke-produkte-' + currentUser.username, JSON.stringify(imported.produkte));
                         localStorage.setItem('getraenke-eingaben-' + currentUser.username, JSON.stringify(imported.eingaben));
+                        if (imported.inventar) {
+                            localStorage.setItem('getraenke-inventar-' + currentUser.username, JSON.stringify(imported.inventar));
+                        }
+                        if (imported.todos) {
+                            localStorage.setItem('getraenke-todos-' + currentUser.username, JSON.stringify(imported.todos));
+                        }
                         alert('Import erfolgreich! Seite wird neu geladen.');
                         location.reload();
                     } else {
@@ -1149,6 +1308,8 @@
             if (confirm('Wirklich alle Daten löschen und zurücksetzen?')) {
                 localStorage.removeItem('getraenke-produkte-' + currentUser.username);
                 localStorage.removeItem('getraenke-eingaben-' + currentUser.username);
+                localStorage.removeItem('getraenke-inventar-' + currentUser.username);
+                localStorage.removeItem('getraenke-todos-' + currentUser.username);
                 location.reload();
             }
         });
@@ -1165,6 +1326,8 @@
                 document.getElementById('currentUserDisplay').textContent = '👤 ' + currentUser.username;
                 loadData();
                 updateProduktDropdown();
+                updateInventarDropdown();
+                updateTodoList();
                 updateTables();
                 updateStats();
             } else {


### PR DESCRIPTION
## Summary
- add separate "Inventar" tab for independent stock entries
- introduce a new "To-Do" tab with persistent tasks
- store inventory and todo data in localStorage and include in backup/import
- remove automatic inventory adjustments when entries change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68441cdccda483208317d8e83b77e2ac